### PR TITLE
CHANGELOG and README proposal for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog CAMARA SimSwap
+
+## Table of Contents
+
+- [v0.4.1](#v041)
+
+# v0.4.1
+
+**This is the first alpha release of the CAMARA SimSwap API**
+
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml)
+
+## Please note:
+
+- This is an alpha version, it should be considered as a draft
+- There are bug fixes to be expected and incompatible changes in upcoming versions 
+- The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments
+- Version numbers before v0.4.1 were used during the development of this version but not released
+- [GSMA Mobile Connect Account Takeover Protection specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.24-Mobile-Connect-Account-Takeover-Protection-Definition-and-Technical-Requirements-v2.0.pdf) was used as source of input for this API. For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
+
+## What's Changed
+
+* SimSwap OAS with 2 endpoints (check & get date) by @bigludo7 in https://github.com/camaraproject/SimSwap/pull/7
+* Added API documentation for the 2-endpoints SIM Swap API by @bigludo7 in https://github.com/camaraproject/SimSwap/pull/9
+* Reshaping the content (+readme.md update) by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/13
+* Update README.MD by @jlurien in https://github.com/camaraproject/SimSwap/pull/17
+* Guidelines alignment regarding errors and camel case by @monamok in https://github.com/camaraproject/SimSwap/pull/20
+* Glossary alignment by @monamok in https://github.com/camaraproject/SimSwap/pull/40
+* Cleaning up repo by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/48
+* Fixing version by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/50
+* Consolidate api information into yaml file by @fernandopradocabrillo in https://github.com/camaraproject/SimSwap/pull/52
+
+## New Contributors
+* @monamok made their first contribution in https://github.com/camaraproject/SimSwap/pull/3
+* @DT-DawidWroblewski made their first contribution in https://github.com/camaraproject/SimSwap/pull/8
+* @bigludo7 made their first contribution in https://github.com/camaraproject/SimSwap/pull/7
+* @jlurien made their first contribution in https://github.com/camaraproject/SimSwap/pull/17
+* @fernandopradocabrillo made their first contribution in https://github.com/camaraproject/SimSwap/pull/46
+
+**Full Changelog**: https://github.com/camaraproject/SimSwap/commits/v0.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 **This is the first alpha release of the CAMARA SimSwap API**
 
 - API definition **with inline documentation**:
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/release-0.4.0/code/API_definitions/sim_swap.yaml)
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml&nocors) 
   - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml)
 
@@ -30,6 +30,9 @@
 * Guidelines alignment regarding errors and camel case by @monamok in https://github.com/camaraproject/SimSwap/pull/20
 * Glossary alignment by @monamok in https://github.com/camaraproject/SimSwap/pull/40
 * Cleaning up repo by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/48
+* Created a release branch release-0.4.0 based on [commit 6843563](https://github.com/camaraproject/SimSwap/commit/6843563242709cc82c6d5ea3cd6d484f14e44bfe)
+* Fixed the security schema as agreed to three-legged only within the release branch
+* Created CHANGELOG.md and updated README.md within the release branch
 
 ## New Contributors
 * @monamok made their first contribution in https://github.com/camaraproject/SimSwap/pull/3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - This is an alpha version, there are bug fixes to be expected and incompatible changes in upcoming versions 
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments
 - Version numbers before v0.4.0 were used during the development of this version but not released
-- [GSMA Mobile Connect Account Takeover Protection specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.24-Mobile-Connect-Account-Takeover-Protection-Definition-and-Technical-Requirements-v2.0.pdf) was used as source of input for this API. For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
 
 ## What's New
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,23 @@
 
 ## Table of Contents
 
-- [v0.4.1](#v041)
+- [v0.4.0](#v040)
 
-# v0.4.1
+# v0.4.0
 
 **This is the first alpha release of the CAMARA SimSwap API**
 
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml&nocors) 
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml)
 
 ## Please note:
 
 - This is an alpha version, it should be considered as a draft
 - There are bug fixes to be expected and incompatible changes in upcoming versions 
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments
-- Version numbers before v0.4.1 were used during the development of this version but not released
+- Version numbers before v0.4.0 were used during the development of this version but not released
 - [GSMA Mobile Connect Account Takeover Protection specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.24-Mobile-Connect-Account-Takeover-Protection-Definition-and-Technical-Requirements-v2.0.pdf) was used as source of input for this API. For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
 
 ## What's Changed
@@ -30,8 +30,6 @@
 * Guidelines alignment regarding errors and camel case by @monamok in https://github.com/camaraproject/SimSwap/pull/20
 * Glossary alignment by @monamok in https://github.com/camaraproject/SimSwap/pull/40
 * Cleaning up repo by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/48
-* Fixing version by @DT-DawidWroblewski in https://github.com/camaraproject/SimSwap/pull/50
-* Consolidate api information into yaml file by @fernandopradocabrillo in https://github.com/camaraproject/SimSwap/pull/52
 
 ## New Contributors
 * @monamok made their first contribution in https://github.com/camaraproject/SimSwap/pull/3
@@ -40,4 +38,4 @@
 * @jlurien made their first contribution in https://github.com/camaraproject/SimSwap/pull/17
 * @fernandopradocabrillo made their first contribution in https://github.com/camaraproject/SimSwap/pull/46
 
-**Full Changelog**: https://github.com/camaraproject/SimSwap/commits/v0.4.1
+**Full Changelog**: https://github.com/camaraproject/SimSwap/commits/v0.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,12 @@
 
 ## Please note:
 
-- This is an alpha version, it should be considered as a draft
-- There are bug fixes to be expected and incompatible changes in upcoming versions 
+- This is an alpha version, there are bug fixes to be expected and incompatible changes in upcoming versions 
 - The release is suitable for implementors, but it is not recommended to use the API with customers in productive environments
 - Version numbers before v0.4.0 were used during the development of this version but not released
 - [GSMA Mobile Connect Account Takeover Protection specification](https://www.gsma.com/identity/wp-content/uploads/2022/12/IDY.24-Mobile-Connect-Account-Takeover-Protection-Definition-and-Technical-Requirements-v2.0.pdf) was used as source of input for this API. For more about Mobile Connect, please see [Mobile Connect website](https://mobileconnect.io/).
 
-## What's Changed
+## What's New
 
 * SimSwap OAS with 2 endpoints (check & get date) by @bigludo7 in https://github.com/camaraproject/SimSwap/pull/7
 * Added API documentation for the 2-endpoints SIM Swap API by @bigludo7 in https://github.com/camaraproject/SimSwap/pull/9

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ Repository to describe, develop, document and test the SimSwap API family
 ## Status and released versions
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
-* **The latest available release and version of CAMARA SimSwap API is 0.4.1. This is the first alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
-* Release 0.4.1 of the API is available within the [release-0.4.1 branch](https://github.com/camaraproject/SimSwap/tree/release-0.4.1):
-  - API definition **with inline documentation**:
-    - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml)
+* **The latest available release and version of CAMARA SimSwap API is 0.4.0. This is the first alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* Release 0.4.0 of the API is available within the [release-0.4.0 branch](https://github.com/camaraproject/SimSwap/tree/release-0.4.0):
+- API definition **with inline documentation**:
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml&nocors) 
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml)
 
 ## Contributorship and mailing list
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Repository to describe, develop, document and test the SimSwap API family
 * **The latest available release and version of CAMARA SimSwap API is 0.4.0. This is the first alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
 * Release 0.4.0 of the API is available within the [release-0.4.0 branch](https://github.com/camaraproject/SimSwap/tree/release-0.4.0):
 - API definition **with inline documentation**:
-  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
+  - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/release-0.4.0/code/API_definitions/sim_swap.yaml)
   - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml&nocors) 
   - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/v0.4.0/code/API_definitions/sim_swap.yaml)
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,16 @@ Repository to describe, develop, document and test the SimSwap API family
 * Meetings are held virtually in MS Teams
 * Current schedule & meeting links: [Meetings information](documentation/MeetingMinutes/README.MD)
 
-## Results
+## Status and released versions
 
-* Sub Project is in progress
+* Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
+* **The latest available release and version of CAMARA SimSwap API is 0.4.1. This is the first alpha version of the API.** There are bug fixes to be expected and incompatible changes in upcoming releases. It is suitable for implementors, but it is not recommended to use the API with customers in productive environments.
+* Release 0.4.1 of the API is available within the [release-0.4.1 branch](https://github.com/camaraproject/SimSwap/tree/release-0.4.1):
+  - API definition **with inline documentation**:
+    - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/main/code/API_definitions/sim_swap.yaml)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/main/code/API_definitions/sim_swap.yaml)
+
 
 ## Contributorship and mailing list
 


### PR DESCRIPTION
#### What type of PR is this?

* documentation
* subproject management

#### What this PR does / why we need it:

Within #54 I've proposed to create a base, first alpha release to allow implementators to start with a release and make further changes more transparent via the repository changelog. The PR contains a proposal for the initial CHANGELOG.md and the change for the README.md

If accepted, the merge commit of the PR would then be the one which should be tagged as v0.4.1 and with get the branch release-0.4.1

#### Which issue(s) this PR fixes:

Fixes #54 

#### Special notes for reviewers:

The general content is based on the QoD repo files, there might be copy&paste errors.

#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
