### PR TITLE
Removing dot from end of SIM_SWAP.UNKNOWN_PHONE_NUMBER response message. This is to align with other response messages.

### DIFF
--- a/code/API_definitions/sim_swap.yaml
+++ b/code/API_definitions/sim_swap.yaml
@@ -250,7 +250,7 @@ components:
           example:
             status: 404
             code: SIM_SWAP.UNKNOWN_PHONE_NUMBER
-            message: SIM Swap can't be checked because the phone number is unknown.
+            message: SIM Swap can't be checked because the phone number is unknown
     Generic409:
       description: Conflict
       content:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:

This is a tiny change! Removing only 1 character from the spec. 

Have removed the dot at the end of the message for SIM_SWAP.UNKNOWN_PHONE_NUMBER.

i.e. `"SIM Swap can't be checked because the phone number is unknown."` has been changed to `"SIM Swap can't be checked because the phone number is unknown"` (notice that the dot is removed at the end of the message).

This is simply to align the SIM_SWAP.UNKNOWN_PHONE_NUMBER message with the other non-200 response messages. They all lack the dot at the end of the message. For example, "Client does not have sufficient permissions to perform this action"

#### Which issue(s) this PR fixes:

I did not create an issue for this - it seemed too small to raise an issue for. I can raise one if required.

#### Special notes for reviewers:

I was reviewing the existing spec in context of GSMA certification/testing and noticed the discrepancy. 

#### Changelog input

```
 release-note

The message value in the 404 SIM_SWAP.UNKNOWN_PHONE_NUMBER response has been slightly amended to remove a trailing dot/period. This is to align with the other non-200 response messages (they do not have trailing dot/periods). 

```

#### Additional documentation 

N/A
