### PR TITLE
add subscriptionMaxEvents for maximum number of SIMSwap notifications

### DIFF
--- a/code/API_definitions/sim-swap-notification-subscription.yaml
+++ b/code/API_definitions/sim-swap-notification-subscription.yaml
@@ -545,9 +545,10 @@ components:
     TerminationReason:
       type: string
       description: |
-        NETWORK_TERMINATED - API server stopped sending notification
-        SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
-        MAX_EVENTS_REACHED - maximum number of events (optionally set by the requester) has been reached
+        - NETWORK_TERMINATED - API server stopped sending notification
+        - SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        - MAX_EVENTS_REACHED - Maximum number of events (optionally set by the requester) has been reached
+
       enum:
         - MAX_EVENTS_REACHED
         - NETWORK_TERMINATED

--- a/code/API_definitions/sim-swap-notification-subscription.yaml
+++ b/code/API_definitions/sim-swap-notification-subscription.yaml
@@ -31,8 +31,11 @@ info:
 
 
     Note: Additionally to these list, ``org.camaraproject.sim-swap.v0.subscription-ends`` notification `type` is sent when the subscription ends. 
-    This notification does not require a dedicated subscription. 
-    It is used when the subscription expire time (required by the requester) has been reached or if the API server has to terminate subscription (e.g. when the corresponding phone number is not served by the operator anymore). 
+    This notification does not require dedicated subscription. 
+    It is used when:
+      - the subscription expire time (optionally set by the requester) has been reached 
+      - the maximum number of subscription events (optionally set by the requester) has been reached
+      - the API server has to stop sending notification prematurely
 
     ### Notification callback
 
@@ -329,6 +332,11 @@ components:
           format: date-time
           example: 2023-01-17T13:18:23.682Z
           description: The subscription expiration time in date-time format.
+        subscriptionMaxEvents:
+          type: integer
+          description: Identifies the maximum number of event reports to be generated (>=1) - Once this number is reached, the subscription ends.
+          minimum: 1
+          example: 5
         webhook:
           $ref: '#/components/schemas/Webhook'
 
@@ -528,12 +536,23 @@ components:
         phoneNumber:
           $ref: '#/components/schemas/PhoneNumber'
         terminationReason:
-          type: string
-          enum: ["SUBSCRIPTION_EXPIRED", "NETWORK_TERMINATED"]
+          $ref: "#/components/schemas/TerminationReason"
         subscriptionId:
           $ref: "#/components/schemas/SubscriptionId"
         terminationDescription:
           type: string
+
+    TerminationReason:
+      type: string
+      description: |
+        NETWORK_TERMINATED - API server stopped sending notification
+        SUBSCRIPTION_EXPIRED - Subscription expire time (optionally set by the requester) has been reached
+        MAX_EVENTS_REACHED - maximum number of events (optionally set by the requester) has been reached
+      enum:
+        - MAX_EVENTS_REACHED
+        - NETWORK_TERMINATED
+        - SUBSCRIPTION_EXPIRED
+
 
   responses:
     Generic400:


### PR DESCRIPTION


#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature


#### What this PR does / why we need it:

Update sim-swap-notification-subscription.yaml
add subscriptionMaxEvents for maximum number of notifications for alignement with commonalities guideline


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #90 

#### Special notes for reviewers:

I keep the version as 0.1.0-wip

#### Changelog input

```
 release-note
- add subscriptionMaxEvents attribute in subscription request to allow API consumer to ask for maximum number of notifications

```

#### Additional documentation 

This section can be blank.



```
docs

```
