### PR TITLE
add API-Name aka wild-card scope

### DIFF
--- a/code/API_definitions/sim_swap.yaml
+++ b/code/API_definitions/sim_swap.yaml
@@ -68,6 +68,8 @@ paths:
       security:
         - openId:
           - sim-swap:retrieve-date
+        - openId:
+          - sim-swap
       tags:
         - Retrieve SIM swap date
       description: Get timestamp of last MSISDN <-> IMSI pairing change for a mobile user account provided with MSIDN.
@@ -113,6 +115,8 @@ paths:
       security:
         - openId:
           - sim-swap:check
+        - openId:
+          - sim-swap
       tags:
       - Check SIM swap
       description: Check if SIM swap has been performed during a past period

--- a/code/API_definitions/sim_swap.yaml
+++ b/code/API_definitions/sim_swap.yaml
@@ -67,9 +67,9 @@ paths:
     post:
       security:
         - openId:
-          - sim-swap:retrieve-date
+            - sim-swap:retrieve-date
         - openId:
-          - sim-swap
+            - sim-swap
       tags:
         - Retrieve SIM swap date
       description: Get timestamp of last MSISDN <-> IMSI pairing change for a mobile user account provided with MSIDN.
@@ -114,9 +114,9 @@ paths:
     post:
       security:
         - openId:
-          - sim-swap:check
+            - sim-swap:check
         - openId:
-          - sim-swap
+            - sim-swap
       tags:
         - Check SIM swap
       description: Check if SIM swap has been performed during a past period


### PR DESCRIPTION
#### What type of PR is this?

Allow clients to request the scope `sim-swap` and get access to both sim-swap-check and sim-swap-data

#### What this PR does / why we need it:

Let the SimSwap subgroup define support for the wildcard scope `sim-swap`.


See also: https://github.com/camaraproject/Commonalities/issues/184#issuecomment-2093391516