### PR TITLE
Correction of broken links in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,8 +57,8 @@ This version contains significant changes compared to v0.4.0, and it is not back
 
 - API definition **with inline documentation**:
     - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim-swap-subscriptions.yaml)
-    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim-swap-subscriptions&nocors)
-    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim-swap-subscriptions)
+    - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.1/code/API_definitions/sim-swap-subscriptions&nocors)
+    - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.1/code/API_definitions/sim-swap-subscriptions)
 
 ## Please note:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,8 @@ This version contains significant changes compared to v0.4.0, and it is not back
 
 - API definition **with inline documentation**:
   - OpenAPI [YAML spec file](https://github.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim_swap.yaml)
-  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim_swap.yaml&nocors)
-  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/blob/r1.1/code/API_definitions/sim_swap.yaml)
+  - [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.1/code/API_definitions/sim_swap.yaml&nocors)
+  - [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.1/code/API_definitions/sim_swap.yaml)
 
 ### Added
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction

#### What this PR does / why we need it:

Correct the links to raw YAML file for Redoc and Swagger (removed `blob/`)


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

n/a - minor change

#### Special notes for reviewers:

Update r1.1 release description as well.


