### PR TITLE
Contact and TermsOfService fields should be removed from info object 

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -58,13 +58,10 @@ info:
 
     (FAQs will be added in a later version of the documentation)
 
-  termsOfService: http://swagger.io/terms/
-  contact:
-    email: project-email@sample.com
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0-alpha.1
+  version: wip
   x-camara-commonalities: 0.4.0
 
 externalDocs:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -72,13 +72,10 @@ info:
 
     (FAQs will be added in a later version of the documentation)
 
-  termsOfService: http://swagger.io/terms/
-  contact:
-    email: project-email@sample.com
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 1.0.0-rc.1
+  version: wip
   x-camara-commonalities: 0.4.0
 externalDocs:
   description: Product documentation at Camara


### PR DESCRIPTION



#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Removed Contact and TermsOfService fields from info object 


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #141 

#### Special notes for reviewers:

version back to `wip`

#### Changelog input

```
 release-note
-Removed Contact and TermsOfService fields from info object 

```

#### Additional documentation 

This section can be blank.



```
docs

```
