### PR TITLE
Remove obsolete/wrong statement in API description that "either one or both endpoints could be implemented"

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -17,8 +17,6 @@ info:
     * When did the last SIM swap occur?
     * Has a SIM swap occurred during last n hours?
 
-    Depending on the network provider implementation, legal enforcement, etc... either one or both endpoints could be implemented.
-
     # Relevant terms and definitions
 
     **SIM swap**:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Remove obsolete/wrong statement in API description that "either one or both endpoints could be implemented"



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #144 
