### PR TITLE
Correction of broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Repository to describe, develop, document and test the SimSwap API family
 * `NEW`: Release r1.2 features following APIs:
   * version 1.0.0 of the **API sim-swap** - available [here](https://github.com/camaraproject/SimSwap/tree/r1.2)
     * API definitions **with inline documentation**):
-      * OpenAPI [YAML](https://github.com/camaraproject/SimSwap/blob/r1.2/code/API_definitions/sim_swap.yaml)
-      * [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.2/code/API_definitions/sim_swap.yaml&nocors) 
-      * [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.2/code/API_definitions/sim_swap.yaml)
+      * OpenAPI [YAML](https://github.com/camaraproject/SimSwap/blob/r1.2/code/API_definitions/sim-swap.yaml)
+      * [View it on ReDoc](https://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.2/code/API_definitions/sim-swap.yaml&nocors) 
+      * [View it on Swagger Editor](https://editor.swagger.io/?url=https://raw.githubusercontent.com/camaraproject/SimSwap/r1.2/code/API_definitions/sim-swap.yaml)
   * version 0.1.0 of the **API sim-swap-subscriptions** - available [here](https://github.com/camaraproject/SimSwap/tree/r1.2)
      * API definitions **with inline documentation**:
        * OpenAPI [YAML](https://github.com/camaraproject/SimSwap/blob/r1.2/code/API_definitions/sim-swap-subscriptions.yaml)


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

Correction


#### What this PR does / why we need it:

The links to the SimSwap YAML where still to sim_swap.yaml and there broken.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # na

#### Special notes for reviewers:

Please note that the links within https://github.com/camaraproject/SimSwap/tree/r1.2/README.md would be still broken after the merge of this PR. Therefore I recommend to move the release tag r1.2 to towards the merge commit of this correction PR (can be done without harm as none of the release assets were touched).

