### PR TITLE
Add EventSimSwap to Sim Swap Subscriptions

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -26,7 +26,7 @@ info:
 
     It is mandatory in the subscription to provide the event `types` subscribed are several are managed in this API.
 
-    Only one  ``types`` is managed for this API:
+    Only one event ``types`` is managed for this API:
       - ``org.camaraproject.sim-swap-subscriptions.v0.swapped`` - Event triggered when a sim swap occurs on the associated phoneNumber
 
 

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -677,7 +677,7 @@ components:
       format: date-time
       description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
       example: "2018-04-05T17:31:00Z"
-     
+
     EventSimSwap:
       description: event structure for event sim swapped
       allOf:

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -693,6 +693,15 @@ components:
             data:
               $ref: "#/components/schemas/SubscriptionEnds"
 
+    EventSimSwap:
+      description: event structure for event sim swapped
+      allOf:
+        - $ref: "#/components/schemas/CloudEvent"
+        - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/Swapped"
+
     Swapped:
       description: Event detail structure for ROAMING_ON & ROAMING_OFF event
       type: object

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -61,14 +61,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.1.0
+  version: wip
   x-camara-commonalities: 0.4.0
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 servers:
-  - url: '{apiRoot}/sim-swap-subscriptions/v0.1'
+  - url: '{apiRoot}/sim-swap-subscriptions/vwip'
 
     variables:
       apiRoot:

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -26,7 +26,7 @@ info:
 
     It is mandatory in the subscription to provide the event `types` subscribed are several are managed in this API.
 
-    Only one event ``types`` is managed for this API:
+    Only one  ``types`` is managed for this API:
       - ``org.camaraproject.sim-swap-subscriptions.v0.swapped`` - Event triggered when a sim swap occurs on the associated phoneNumber
 
 
@@ -677,12 +677,15 @@ components:
       format: date-time
       description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
       example: "2018-04-05T17:31:00Z"
-
-    Event-typeEvent:
-      description: event structure for event-type event
+     
+    EventSimSwap:
+      description: event structure for event sim swapped
       allOf:
         - $ref: "#/components/schemas/CloudEvent"
         - type: object
+          properties:
+            data:
+              $ref: "#/components/schemas/Swapped"
 
     EventSubscriptionEnds:
       description: event structure for event subscription ends
@@ -692,15 +695,6 @@ components:
           properties:
             data:
               $ref: "#/components/schemas/SubscriptionEnds"
-
-    EventSimSwap:
-      description: event structure for event sim swapped
-      allOf:
-        - $ref: "#/components/schemas/CloudEvent"
-        - type: object
-          properties:
-            data:
-              $ref: "#/components/schemas/Swapped"
 
     Swapped:
       description: Event detail structure for ROAMING_ON & ROAMING_OFF event


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction


#### What this PR does / why we need it:

Adds the event for a sim swap to the API specification for sim-swap-subscriptions. 


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #156 

