### PR TITLE
Update test wording to avoid confusion with "activation" terminology

### DIFF
--- a/code/Test_definitions/sim-swap-retrieveDate.feature
+++ b/code/Test_definitions/sim-swap-retrieveDate.feature
@@ -44,11 +44,11 @@ Feature: CAMARA SIM Swap API, 1.0.0 - Operation retrieveSimSwapDate
     Then the response status code is 200
     And the response property "$.latestSimChange" contains the sim's activation timestamp
 
-  # This test applies if the operator allows to do the request for a sim that has never been connected to the network
-  @retrieve_sim_swap_date_4_sim_never_connected
-  Scenario: Retrieves SIM swap date for a sim that has never been connected to the network
+  # This test applies if the operator allows to do the request for a phone number that hasn't been associated with a sim card yet
+  @retrieve_sim_swap_date_4_sim_never_associated
+  Scenario: Retrieves SIM swap date for a phone number that has never been associated with a sim card
     Given a valid phone number identified by the token or provided in the request body
-    And the sim for that phone number has never been connected to the Operator's network
+    And the phone number is not associated to any sim card
     When the request "retrieveSimSwapDate" is sent
     Then the response status code is 200
     And the response property "$.latestSimChange" is null

--- a/code/Test_definitions/sim-swap-retrieveDate.feature
+++ b/code/Test_definitions/sim-swap-retrieveDate.feature
@@ -45,10 +45,10 @@ Feature: CAMARA SIM Swap API, 1.0.0 - Operation retrieveSimSwapDate
     And the response property "$.latestSimChange" contains the sim's activation timestamp
 
   # This test applies if the operator allows to do the request for a sim that has never been connected to the network
-  @retrieve_sim_swap_date_4_sim_not_activated
-  Scenario: Retrieves SIM swap date for a non-activated sim
+  @retrieve_sim_swap_date_4_sim_never_connected
+  Scenario: Retrieves SIM swap date for a sim that has never been connected to the network
     Given a valid phone number identified by the token or provided in the request body
-    And the sim for that device has never been connected to the Operator's network
+    And the sim for that phone number has never been connected to the Operator's network
     When the request "retrieveSimSwapDate" is sent
     Then the response status code is 200
     And the response property "$.latestSimChange" is null


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction
* tests


#### What this PR does / why we need it:

Updates test @retrieve_sim_swap_date_4_*  wording


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #169 
