### PR TITLE
fix: remove allof in sinkcredential

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -366,9 +366,7 @@ components:
           description: The address to which events shall be delivered using the selected protocol.
           example: "https://endpoint.example.com/sink"
         sinkCredential:
-          allOf:
-            - description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
-            - $ref: "#/components/schemas/SinkCredential"
+          $ref: "#/components/schemas/SinkCredential"
         types:
           description: |
             Camara Event types eligible for subscription:
@@ -420,6 +418,7 @@ components:
           example: 2025-01-17T13:18:23.682Z
           description: The subscription expiration time (in date-time format) requested by the API consumer. Up to API project decision to keep it.
     SinkCredential:
+      description: A sink credential provides authentication or authorization information necessary to enable delivery of events to a target.
       type: object
       properties:
         credentialType:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction

#### What this PR does / why we need it:
Removing this `allOf`.
It was discovered for some code-generator, it will produce unexpected behaviours having the `description` inside the `allOf`.

#### Which issue(s) this PR fixes:

Fixes #174

#### Changelog input
```
[sim-swap-subscriptions]: remove `allOf` in `sinkCredential` in `SubscriptionRequest` component
```
