### PR TITLE
Add 400 OUT_OF_RANGE error when the maxAge is above 2400

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -288,6 +288,7 @@ components:
                   code:
                     enum:
                       - INVALID_ARGUMENT
+                      - OUT_OF_RANGE
           examples:
             GENERIC_400_INVALID_ARGUMENT:
               description: Invalid Argument. Generic Syntax Exception
@@ -295,6 +296,12 @@ components:
                 status: 400
                 code: INVALID_ARGUMENT
                 message: Client specified an invalid argument, request body or query param.
+            GENERIC_400_OUT_OF_RANGE:
+              description: Out of Range. Specific Syntax Exception used when a given field has a pre-defined range or a invalid filter criteria combination is requested
+              value:
+                status: 400
+                code: OUT_OF_RANGE
+                message: Client specified an invalid range.
     Generic401:
       description: Unauthorized
       headers:

--- a/code/Test_definitions/sim-swap-check.feature
+++ b/code/Test_definitions/sim-swap-check.feature
@@ -188,3 +188,12 @@ Feature: CAMARA SIM Swap API, 2.0.0-rc.1 - Operation checkSimSwap
     And the response property "$.status" is 400
     And the response property "$.code" is "INVALID_ARGUMENT"
     And the response property "$.message" contains a user friendly text
+
+  @check_sim_swap_400.3_invalid_max_age_value
+  Scenario: Check that the response shows an error when the max age is above the limit
+    Given the request body property "$.maxAge" is set to 100000
+    When the request "checkSimSwap" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "OUT_OF_RANGE"
+    And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* enhancement/feature



#### What this PR does / why we need it:

- Add 400 OUT_OF_RANGE error when the maxAge is above 2400


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #187 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- Add 403 with code OUT_OF_RANGE when the maxAge is above 2400


```

#### Additional documentation 

This section can be blank.



```
docs

```
