### PR TITLE
[Sim-Swap-Subscriptions]: Document that `subscription-ends` notification is also sent when deleted by requester

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -35,6 +35,7 @@ info:
     It is used when:
       - the subscription expiration time (optionally set by the requester) has been reached
       - the maximum number of subscription events (optionally set by the requester) has been reached
+      - the subscription was deleted by the requester
       - the API server has to stop sending notification prematurely
       - the Access Token sinkCredential expiration time (set by the requester) has been reached
 


### PR DESCRIPTION


#### What type of PR is this?

Add one of the following kinds:
* documentation

#### What this PR does / why we need it:
Adds documentation:

```yaml
      - the subscription was deleted by the requester
```



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #198 


