### PR TITLE
[Sim-Swap-Subscriptions]: Remove `phoneNumber` from the required properties in the Swap-Event

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -712,7 +712,6 @@ components:
       description: Event detail structure for ROAMING_ON & ROAMING_OFF event
       type: object
       required:
-        - phoneNumber
         - subscriptionId
       properties:
         phoneNumber:
@@ -732,6 +731,7 @@ components:
         subscriptionId:
           $ref: "#/components/schemas/SubscriptionId"
         terminationDescription:
+          description: Explanation why a subscription ended or had to end.
           type: string
 
     TerminationReason:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
The `phoneNumber` is optional in the Event, when 3-legged-token was used.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #197 