### PR TITLE
[Sim-Swap-Subscriptions]: remove `SUBSCRIPTION_MISMATCH` error-code

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -1085,7 +1085,6 @@ components:
                   code:
                     enum:
                       - PERMISSION_DENIED
-                      - SUBSCRIPTION_MISMATCH
           examples:
             GENERIC_403_PERMISSION_DENIED:
               description: Permission denied. OAuth2 token access does not have the required scope or when the user fails operational security
@@ -1093,12 +1092,6 @@ components:
                 status: 403
                 code: PERMISSION_DENIED
                 message: Client does not have sufficient permissions to perform this action.
-            GENERIC_403_SUBSCRIPTION_MISMATCH:
-              description: Inconsistent access token for requested subscription
-              value:
-                status: 403
-                code: "SUBSCRIPTION_MISMATCH"
-                message: "Inconsistent access token for requested events subscription"
     Generic404:
       description: Resource Not Found
       headers:


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* correction


#### What this PR does / why we need it:
Removed `SUBSCRIPTION_MISMATCH` error as it is not applicable when only one event type can be subscribed to.



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #194 


#### Changelog input

```
 release-note
 * [Sim-Swap-Subscriptions]: remove `SUBSCRIPTION_MISMATCH` error-code
```