### PR TITLE
Add a documentation note when regulations prevent less than 100 days for check

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -36,6 +36,9 @@ info:
 
     - POST check: Checks if SIM swap has been performed during a past period (defined in the request with 'maxAge' attribute) for a given phone number.
 
+    Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours.
+    If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a delay inferior to 2400 but superior to operator policy a error '400 OUT_OF_RANGE' is expected with an explicit message to explain the limitation like 'Check monitor period could not exceed local regulation (30 days)'.
+
     # Authorization and authentication
 
     The "Camara Security and Interoperability Profile" provides details of how an API consumer requests an access token. Please refer to Identity and Consent Management (https://github.com/camaraproject/IdentityAndConsentManagement/) for the released version of the profile.

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -36,7 +36,7 @@ info:
 
     - POST check: Checks if SIM swap has been performed during a past period (defined in the request with 'maxAge' attribute) for a given phone number.
 
-      - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a delay inferior to 2400 but superior to operator policy a error '400 OUT_OF_RANGE' is expected with an explicit message to explain the limitation like 'Check monitor period could not exceed local regulation (30 days)'.
+      - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then,  an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
 
     # Authorization and authentication
 

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -36,8 +36,7 @@ info:
 
     - POST check: Checks if SIM swap has been performed during a past period (defined in the request with 'maxAge' attribute) for a given phone number.
 
-    Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours.
-    If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a delay inferior to 2400 but superior to operator policy a error '400 OUT_OF_RANGE' is expected with an explicit message to explain the limitation like 'Check monitor period could not exceed local regulation (30 days)'.
+      - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a delay inferior to 2400 but superior to operator policy a error '400 OUT_OF_RANGE' is expected with an explicit message to explain the limitation like 'Check monitor period could not exceed local regulation (30 days)'.
 
     # Authorization and authentication
 


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* documentation



#### What this PR does / why we need it:

Add a documentation note to explicit how to behave when regulations prevent less than 100 days for the check operation.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #190 

#### Special notes for reviewers:



#### Changelog input

```
 release-note
- Add a documentation note to explicit how to behave when regulations prevent less than 100 days for the check operation.

```

#### Additional documentation 

This section can be blank.



```
docs

```
