### PR TITLE
Remove AUTHENTICATION_REQUIRED error code

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -1037,20 +1037,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
     Generic403:
       description: Client does not have sufficient permission
       headers:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -322,20 +322,13 @@ components:
                   code:
                     enum:
                       - UNAUTHENTICATED
-                      - AUTHENTICATION_REQUIRED
           examples:
             GENERIC_401_UNAUTHENTICATED:
-              description: Request cannot be authenticated
+              description: Request cannot be authenticated and a new authentication is required
               value:
                 status: 401
                 code: UNAUTHENTICATED
-                message: Request not authenticated due to missing, invalid, or expired credentials.
-            GENERIC_401_AUTHENTICATION_REQUIRED:
-              description: New authentication is needed, authentication is no longer valid
-              value:
-                status: 401
-                code: AUTHENTICATION_REQUIRED
-                message: New authentication is required.
+                message: Request not authenticated due to missing, invalid, or expired credentials. A new authentication is required.
     Generic403:
       description: Forbidden
       headers:

--- a/code/Test_definitions/sim-swap-check.feature
+++ b/code/Test_definitions/sim-swap-check.feature
@@ -157,18 +157,6 @@ Feature: CAMARA SIM Swap API, vwip - Operation checkSimSwap
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @check_sim_swap_401.4_expired_access_token
-  Scenario: Expired access token
-  # alternative to scenario @check_sim_swap_401.2_expired_access_token
-    Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
-    When the request "checkSimSwap" is sent
-    Then the response status code is "401"
-    And the response property "$.status" is 401
-    And the response property "$.code" is "AUTHENTICATION_REQUIRED"
-    And the response property "$.message" contains a user friendly text
-
-
   # Generic 400 errors
 
   @check_sim_swap_400.1_invalid_phone_number

--- a/code/Test_definitions/sim-swap-retrieveDate.feature
+++ b/code/Test_definitions/sim-swap-retrieveDate.feature
@@ -125,17 +125,6 @@ Feature: CAMARA SIM Swap API, vwip - Operation retrieveSimSwapDate
     And the response property "$.code" is "UNAUTHENTICATED"
     And the response property "$.message" contains a user friendly text
 
-  @retrieve_sim_swap_date_401.4_expired_access_token
-  Scenario: Expired access token
-    # alternative to scenario @retrieve_sim_swap_date_401.2_expired_access_token
-    Given the header "Authorization" is set to an expired access token
-    And the request body is set to a valid request body
-    When the request "retrieveSimSwapDate" is sent
-    Then the response status code is 401
-    And the response property "$.status" is 401
-    And the response property "$.code" is "AUTHENTICATION_REQUIRED"
-    And the response property "$.message" contains a user friendly text
-
   @retrieve_sim_swap_date_401.3_invalid_access_token
   Scenario: Invalid access token
     Given the header "Authorization" is set to an invalid access token


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:

* correction



#### What this PR does / why we need it:

Commonalities pre-release [r3.1](https://github.com/camaraproject/Commonalities/releases/tag/r3.1) removes the AUTHENTICATION_REQUIRED error code, leaving UNAUTHENTICATED as the only valid error code when the HTTP status code is 401.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #215 

#### Special notes for reviewers:

This is not a breaking change

#### Changelog input

```
 release-note
- Remove AUTHENTICATION_REQUIRED error code

```

#### Additional documentation 

This section can be blank.



```
docs

```
