### PR TITLE
Alignment of API definitions with Commonalities r3.3

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -362,19 +362,19 @@ components:
     ErrorInfo:
       type: object
       required:
+        - message
         - status
         - code
-        - message
       properties:
+        message:
+          type: string
+          description: A human-readable description of what the event represents
         status:
           type: integer
           description: HTTP response status code
         code:
           type: string
-          description: Code given to this error
-        message:
-          type: string
-          description: Detailed error description
+          description: A human-readable code to describe the error
 
     SubscriptionRequest:
       description: The request for creating a sim swap event subscription
@@ -444,7 +444,7 @@ components:
           type: string
           format: date-time
           example: 2025-01-17T13:18:23.682Z
-          description: The subscription expiration time (in date-time format) requested by the API consumer. Up to API project decision to keep it.
+          description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Up to API project decision to keep it.
         subscriptionMaxEvents:
           type: integer
           description: |
@@ -499,7 +499,11 @@ components:
             accessTokenExpiresUtc:
               type: string
               format: date-time
-              description: REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired. In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
+              description: |
+                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+                In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
+                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
+                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
             accessTokenType:
               description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
               type: string
@@ -522,7 +526,11 @@ components:
             accessTokenExpiresUtc:
               type: string
               format: date-time
-              description: REQUIRED. An absolute UTC instant at which the token shall be considered expired.
+              description: |
+                REQUIRED. An absolute (UTC) timestamp at which the token shall be considered expired.
+                In the case of an ACCESS_TOKEN_EXPIRED termination reason, implementation should notify the client before the expiration date.
+                If the access token is a JWT and registered "exp" (Expiration Time) claim is present, the two expiry times should match.
+                It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
             accessTokenType:
               description: REQUIRED. Type of the access token (See [OAuth 2.0](https://tools.ietf.org/html/rfc6749#section-7.1)).
               type: string
@@ -609,7 +617,6 @@ components:
           description: |
             Date when the event subscription will begin/began
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-            Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
           type: string
           format: date-time
           example: "2023-07-03T12:27:08.312Z"
@@ -619,7 +626,6 @@ components:
           description: |
             Date when the event subscription will expire. Only provided when `subscriptionExpireTime` is indicated by API client or Telco Operator has specific policy about that.
             It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
-            Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
           example: "2023-07-03T12:27:08.312Z"
         status:
           type: string
@@ -716,7 +722,7 @@ components:
     DateTime:
       type: string
       format: date-time
-      description: Timestamp of when the occurrence happened. Must adhere to RFC 3339.
+      description: Timestamp of when the occurrence happened. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
       example: "2018-04-05T17:31:00Z"
 
     EventSimSwap:

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -96,14 +96,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 0.3.0-rc.1
+  version: wip
   x-camara-commonalities: 0.6
 
 externalDocs:
   description: Product documentation at CAMARA
   url: https://github.com/camaraproject/
 servers:
-  - url: '{apiRoot}/sim-swap-subscriptions/v0.3-rc1'
+  - url: '{apiRoot}/sim-swap-subscriptions/vwip'
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -362,20 +362,19 @@ components:
     ErrorInfo:
       type: object
       required:
-        - message
         - status
         - code
+        - message
       properties:
-        message:
-          type: string
-          description: A human-readable description of what the event represents
         status:
           type: integer
           description: HTTP response status code
         code:
           type: string
           description: A human-readable code to describe the error
-
+        message:
+          type: string
+          description: A human-readable description of what the event represents
     SubscriptionRequest:
       description: The request for creating a sim swap event subscription
       type: object

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -225,7 +225,7 @@ components:
         latestSimChange:
           type: string
           format: date-time
-          description: Timestamp of latest SIM swap performed. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone. Recommended format is yyyy-MM-dd'T'HH:mm:ss.SSSZ (i.e. which allows 2023-07-03T14:27:08.312+02:00 or 2023-07-03T12:27:08.312Z)
+          description: Timestamp of latest SIM swap performed. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
           nullable: true
           example: "2023-07-03T14:27:08.312+02:00"
         monitoredPeriod:
@@ -249,19 +249,19 @@ components:
     ErrorInfo:
       type: object
       required:
+        - message
         - status
         - code
-        - message
       properties:
+        message:
+          type: string
+          description: A human-readable description of what the event represents
         status:
           type: integer
           description: HTTP response status code
         code:
           type: string
-          description: Code given to this error
-        message:
-          type: string
-          description: Detailed error description
+          description: A human-readable code to describe the error
     CreateCheckSimSwap:
       type: object
       properties:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -77,13 +77,13 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
-  version: 2.1.0-rc.2
+  version: wip
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at Camara
   url: https://github.com/camaraproject/SimSwap
 servers:
-  - url: "{apiRoot}/sim-swap/v2rc2"
+  - url: "{apiRoot}/sim-swap/vwip"
     variables:
       apiRoot:
         default: http://localhost:9091

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -249,19 +249,19 @@ components:
     ErrorInfo:
       type: object
       required:
-        - message
         - status
         - code
+        - message
       properties:
-        message:
-          type: string
-          description: A human-readable description of what the event represents
         status:
           type: integer
           description: HTTP response status code
         code:
           type: string
           description: A human-readable code to describe the error
+        message:
+          type: string
+          description: A human-readable description of what the event represents
     CreateCheckSimSwap:
       type: object
       properties:


### PR DESCRIPTION
#### What type of PR is this?

* Enhancement

#### What this PR does / why we need it:

* reset version in YAML files to wip (intentionally not done for the .feature files to limit merge conflicts)
* cherry-picked https://github.com/camaraproject/SimSwap/pull/229/commits/f3d400a657d030d855979a3af2b7718caa210785 from #229
* reverted the order of ErrorInfo properties back to the one defined in API Design Guide (see issue https://github.com/camaraproject/Commonalities/issues/515) to keep the order in line with the examples 

Merging this PR and update #229 with `main` afterwards will eliminate most of the changes from the release PR which are not belonging there, but there will also the need to resolve some conflicts. Happy to help with that.

#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes # no issue created, but see https://github.com/camaraproject/SimSwap/pull/229#issuecomment-3217033225

#### Special notes for reviewers:

I assumed that the content of https://github.com/camaraproject/SimSwap/pull/229/commits/f3d400a657d030d855979a3af2b7718caa210785, as already reviewed in #229 

#### Changelog input

```
 Alignment with latest changes of Commonalities in release r3.3
```

#### Additional documentation 

This section can be blank.



```
docs

```
