### PR TITLE
Include new test scenario to check maxAge outside of monitored

### DIFF
--- a/code/Test_definitions/sim-swap-checkSimSwap.feature
+++ b/code/Test_definitions/sim-swap-checkSimSwap.feature
@@ -185,3 +185,13 @@ Feature: CAMARA SIM Swap API, v2.1.0-rc.2 - Operation checkSimSwap
     And the response property "$.status" is 400
     And the response property "$.code" is "OUT_OF_RANGE"
     And the response property "$.message" contains a user friendly text
+
+  @check_sim_swap_400.4_max_age_out_of_monitored_period
+  Scenario: Check that the response shows an error when the max age is above the supported monitored period of the API Provider
+    # This test only applies if the API Provider has a restricted monitored period by local regulations
+    Given the request body property "$.maxAge" is set to a valid value above the supported monitored period of the API Provider
+    When the request "checkSimSwap" is sent
+    Then the response status code is 400
+    And the response property "$.status" is 400
+    And the response property "$.code" is "OUT_OF_RANGE"
+    And the response property "$.message" contains a user friendly text


### PR DESCRIPTION
#### What type of PR is this?

Add one of the following kinds:
* enhancement/feature
* tests


#### What this PR does / why we need it:
Include a new test to control when the client requests a maxAge outside of the operator supported value

This PR solves this [comment](https://github.com/camaraproject/SimSwap/pull/229#discussion_r2312504064) from the M4 PR



#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #184 

#### Special notes for reviewers:
This PR should be merge before M4 PR #229 
