### PR TITLE
Use standard Release Information section title

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Incubating API Repository to evolve and maintain the definitions and documentati
 * Started: October 2022
 * Incubating stage since: February 2025
 
-## Status and released versions
+## Release Information
 
 * Note: Please be aware that the project will have frequent updates to the main branch. There are no compatibility guarantees associated with code in any branch, including main, until a new release is created. For example, changes may be reverted before a release is created. **For best results, use the latest available release**.
 * Public release r3.3 features the following APIs:


### PR DESCRIPTION
## Summary
Change section heading to standard "Release Information" title for automated sync.

## Context
The Release Info Sync campaign expects a "Release Information" section heading. This repository currently uses "Status and released versions" which prevents the workflow from processing it.

## Changes
- Change `## Status and released versions` to `## Release Information`

## Testing
After this PR is merged, the release info sync campaign will be able to process this repository and add required markers/update content in the next workflow run.

Related to camaraproject/project-administration#70