### PR TITLE
[WIP] feat: add optional 'ageTiers' for granular risk assessment

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -34,8 +34,9 @@ info:
 
       - If the latest SIM swap date (or the activation date if no SIM swap) cannot be communicated due to local regulations (or MNO internal privacy policies) preventing the safekeeping of the information for longer than the stated period, a `null` value will be returned. Optionally, a `monitoredPeriod` could be provided to indicate monitored time frame (in days) supported by the MNO. In this case the response must be treated as "there were no sim swap events during 'monitoredPeriod'. Either the parameter is optional, it is recommended to support it in SimSwap implementations.
 
-    - POST check: Checks if SIM swap has been performed during a past period (defined in the request with 'maxAge' attribute) for a given phone number.
-
+    - POST check: Checks if SIM swap has been performed during a past period for a given phone number.
+      - The API returns a boolean response (true/false) based on the mandatory 'maxAge' attribute.
+      - Optionally, the client can provide 'ageTiers' (list of time buckets) to receive a 'tierIndex', enabling granular risk assessment without exposing exact timestamps.
       - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then,  an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
 
     # Authorization and authentication
@@ -241,6 +242,21 @@ components:
           type: boolean
           description: Indicates whether the SIM card has been swapped during the
             period within the provided age.
+        # --- NEW FIELD START ---
+        tierIndex:
+          type: integer
+          format: int32
+          description: |
+            OPTIONAL. The 0-based index of the bucket in 'ageTiers' where the actual SIM swap age falls.
+            
+            Logic:
+            1. Iterate through 'ageTiers'.
+            2. Find the first tier where actual_age <= tier_value.
+            3. Return that index.
+            
+            Returns null (or omitted) if the swap age exceeds all defined tiers or if 'ageTiers' was not provided.
+          example: 1
+        # --- NEW FIELD END ---       
     PhoneNumber:
       type: string
       pattern: '^\+[1-9][0-9]{4,14}$'
@@ -276,6 +292,20 @@ components:
           minimum: 1
           maximum: 2400
           default: 240
+        # --- NEW FIELD START ---
+        ageTiers:
+          type: array
+          description: |
+            OPTIONAL. A list of integers defining time buckets (in hours) for risk assessment.
+            The response will contain 'tierIndex' indicating which bucket the actual swap age falls into.
+            If omitted, the API behaves as a standard boolean check.
+          items:
+            type: integer
+            format: int32
+            minimum: 1
+            maximum: 2400
+          example: [1, 4, 24, 72, 240]
+        # --- NEW FIELD END ---
     CreateSimSwapDate:
       type: object
       properties:


### PR DESCRIPTION
Introduce an optional input parameter ageTiers (list of integers) that enables a "Tiered Response" mode, where the highest tier is the maxAge.

What type of PR is this?

enhancement/feature

What this PR does / why we need it:

Introduces an additive, optional mechanism to query SIM swap "recency tiers" without exposing exact timestamps.

Current consumers of the API (e.g., banks) often need more granular signals to assess account-takeover risk alongside their own data for their ML based risk engine (vs the rule based sequential gate). A simple boolean result (True/False) is form of lossy compression and doesn’t provide enough detail, while returning the underlying event date/time isn’t feasible due to strict privacy requirements (e.g., GDPR) and operator restrictions.

Also due to privacy and security reasons, a bank won't want to leak the value/risk of their customer's operation and disclose their internal risk policies to third party by using different maxAge for each individual transactions. The standard age-tier approach will help to protect bank customers' privacy and bank's corporate security.

Solution:

Adds ageTiers (Request): An optional list of integer buckets (e.g., [1, 4, 24]) with max 10 tiers

Adds tierIndex (Response): An optional integer indicating which bucket the swap falls into.

Which issue(s) this PR fixes:

Fixes https://github.com/camaraproject/SimSwap/issues/248

Special notes for reviewers:

Backward Compatibility Analysis: This change is strictly additive.

The maxAge parameter remains required and continues to drive the standard swapped boolean logic.

If ageTiers is omitted by the client (legacy behavior), the API behaves exactly as the current v2.0.0 spec, and tierIndex is not returned.

Privacy Impact: This improvement enhances privacy by allowing operators to share risk granularity without revealing the exact time of the swap (PII). Also allow the banks (Clients) take full advantage of the function without revealing the value/risk of customer's bank transactions/operations.