### PR TITLE
Update sim-swap | add /retrieve-age-band endpoint returning age band …

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: SIM Swap
   description: |
-    The SIM swap API provides a programmable interface for developers and other users (capabilities consumers) to request the last date of a SIM swap performed on the mobile line, or, to check whether a SIM swap has been performed during a past period.
+    The SIM swap API provides a programmable interface for developers and other users (capabilities consumers) to request the last date of a SIM swap performed on the mobile line, to check whether a SIM swap has been performed during a past period, or to retrieve a standardized recency band for the last SIM swap event.
 
     # Introduction
 
@@ -12,10 +12,13 @@ info:
 
     The SIM Swap API can also be used to protect non-automated actions. For example, when a call center expert contacts a user to clarify or confirm a sensitive operation.
 
-    This API is used by an application to get information about a mobile line latest SIM swap date. It can be easily integrated and used through this secured API and allows SPs (Service Provider) to get this information an easy & secured way. The API provides management of 2 endpoints answering 2 distinct questions:
+    This API is used by an application to get information about a mobile line latest SIM swap date. It can be easily integrated and used through this secured API and allows SPs (Service Provider) to get this information an easy & secured way. The API provides management of 3 endpoints answering 3 distinct questions:
 
     * When did the last SIM swap occur?
+
     * Has a SIM swap occurred during last n hours?
+
+    * How long ago did the last SIM swap or activation occur (as a standardized recency band)?
 
     # Relevant terms and definitions
 
@@ -26,7 +29,7 @@ info:
 
     # API functionality
 
-    The API provides 2 operations:
+    The API provides 3 operations:
 
     - POST retrieve-date : Provides timestamp of latest SIM swap, if any, for a given phone number.
 
@@ -36,7 +39,28 @@ info:
 
     - POST check: Checks if SIM swap has been performed during a past period (defined in the request with 'maxAge' attribute) for a given phone number.
 
-      - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then,  an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
+      - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then, an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
+
+    - POST retrieve-age-band : Returns a standardized `simSwapAgeBandEnum` recency bucket representing the elapsed time between the SIM activation/change date and the current time. This endpoint is the dedicated signal for consumers (e.g., banks, fraud platforms) that need coarse time-band context for risk decisioning, ML features, or step-up logic. The consuming party applies its own thresholds outside the API contract. The response carries the band value only — it does NOT include the `swapped` Boolean (scope of `check`) or the change date (scope of `retrieve-date`), per the agreement reached in the 2026-04-29 ad-hoc call (issue #253) and TEF's stance on issue #260.
+
+      - Standardized AgeBand enum mapping: <br>
+        -1 = Subscriber valid, but no real-time profile found <br>
+         0 = Change has not happened <br>
+         1 = 0h ≤ d < 4h <br>
+         2 = 4h ≤ d < 12h <br>
+         3 = 12h ≤ d < 1d <br>
+         4 = 1d ≤ d < 2d <br>
+         5 = 2d ≤ d < 5d <br>
+         6 = 5d ≤ d < 7d <br>
+         7 = 7d ≤ d < 14d <br>
+         8 = 14d ≤ d < 30d <br>
+         9 = 30d ≤ d < 60d <br>
+        10 = 60d ≤ d < 90d <br>
+        11 = 90d ≤ d < 180d <br>
+        12 = 180d ≤ d < 1y <br>
+        13 = 1y ≤ d < 2y <br>
+        14 = 2y ≤ d < 3y <br>
+        15 = 3y+ <br>
 
     # Authorization and authentication
 
@@ -62,11 +86,11 @@ info:
 
     # Additional CAMARA error responses
 
-      The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
+    The list of error codes in this API specification is not exhaustive. Therefore the API specification may not document some non-mandatory error statuses as indicated in `CAMARA API Design Guide`.
 
-      Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
+    Please refer to the `CAMARA_common.yaml` of the Commonalities Release associated to this API version for a complete list of error responses. The applicable Commonalities Release can be identified in the `API Readiness Checklist` document associated to this API version.
 
-      As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
+    As a specific rule, error `501 - NOT_IMPLEMENTED` can be only a possible error response if it is explicitly documented in the API.
 
     # Further info and support
 
@@ -77,7 +101,14 @@ info:
   license:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
+  # Development value. Release target is 2.1.0 (MINOR bump over public 2.0.0:
+  # adding a new endpoint is backward compatible). URL stays /sim-swap/v2 at release.
   version: wip
+  # Commonalities is intentionally kept at 0.6 to match the rest of this API. The newer
+  # business-outcome modeling pattern (contextCode/contextMessage for unknown/unavailable
+  # results) comes from a later Commonalities release; adopting it would be a separate,
+  # larger bump for the whole file and must be raised explicitly with reviewers rather than
+  # changed silently here. Until then, the "no real-time profile" state is the enum value -1.
   x-camara-commonalities: 0.6
 externalDocs:
   description: Product documentation at Camara
@@ -115,7 +146,6 @@ paths:
                 $ref: "#/components/examples/RETRIEVE_3LEGS"
               RETRIEVE_2LEGS:
                 $ref: "#/components/examples/RETRIEVE_2LEGS"
-
         required: true
       responses:
         "200":
@@ -195,6 +225,78 @@ paths:
           $ref: "#/components/responses/Generic422"
         "429":
           $ref: "#/components/responses/Generic429"
+  # New in this PR — third, single-purpose endpoint returning the SIM swap age band ONLY.
+  # Per the 2026-04-29 ad-hoc agreement (#253) and TEF stance (#260) it MUST NOT
+  # re-implement /check (the `swapped` Boolean) or /retrieve-date (the timestamp).
+  /retrieve-age-band:
+    post:
+      security:
+        - openId:
+            - sim-swap:retrieve-age-band
+        - openId:
+            - sim-swap
+      tags:
+        - Retrieve SIM swap age band
+      summary: Retrieve SIM swap age band
+      description: |
+        Returns a standardized `simSwapAgeBandEnum` recency bucket representing the elapsed time
+        between the SIM activation/change date and the current time.
+
+        This endpoint is the dedicated signal for consumers that need coarse time-band context
+        for fraud decisioning, risk scoring, ML features, or step-up logic. The response is
+        intentionally decoupled from `check` (Boolean threshold) and `retrieve-date` (timestamp)
+        to keep each endpoint contract clean and unambiguous. Accordingly, the response contains
+        the age band value ONLY — it does not include the `swapped` Boolean or the change date.
+
+        The consuming party (e.g., a bank or fraud platform) applies its own thresholds outside
+        the API contract based on the returned band value.
+      operationId: retrieveSimSwapAgeBand
+      parameters:
+        - $ref: '#/components/parameters/x-correlator'
+      requestBody:
+        description: |
+          Create a SIM swap age band request for a phone number.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateSimSwapAgeBand"
+            examples:
+              AGEBAND_3LEGS:
+                $ref: "#/components/examples/AGEBAND_3LEGS"
+              AGEBAND_2LEGS:
+                $ref: "#/components/examples/AGEBAND_2LEGS"
+        required: true
+      responses:
+        "200":
+          description: Returns the standardized SIM swap recency band for the given phone number
+          headers:
+            x-correlator:
+              $ref: '#/components/headers/x-correlator'
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SimSwapAgeBandInfo"
+              examples:
+                AGEBAND_RECENT:
+                  $ref: "#/components/examples/AGEBAND_RECENT"
+                AGEBAND_NO_CHANGE:
+                  $ref: "#/components/examples/AGEBAND_NO_CHANGE"
+                AGEBAND_NO_PROFILE:
+                  $ref: "#/components/examples/AGEBAND_NO_PROFILE"
+                AGEBAND_LONG_TERM:
+                  $ref: "#/components/examples/AGEBAND_LONG_TERM"
+        "400":
+          $ref: "#/components/responses/Generic400"
+        "401":
+          $ref: "#/components/responses/Generic401"
+        "403":
+          $ref: "#/components/responses/Generic403"
+        "404":
+          $ref: "#/components/responses/Generic404"
+        "422":
+          $ref: "#/components/responses/Generic422"
+        "429":
+          $ref: "#/components/responses/Generic429"
 components:
   securitySchemes:
     openId:
@@ -241,6 +343,76 @@ components:
           type: boolean
           description: Indicates whether the SIM card has been swapped during the
             period within the provided age.
+    SimSwapAgeBandEnum:
+      type: integer
+      description: |
+        Standardized recency bucket representing the elapsed time between the SIM activation/change
+        date and the current time. The enum is fully standardized to ensure consistent interpretation
+        across operators, aggregators, and consuming applications.
+
+        | Value | Duration band                                         |
+        |-------|-------------------------------------------------------|
+        | -1    | Subscriber valid, but no real-time profile found      |
+        | 0     | Change has not happened                               |
+        | 1     | 0h ≤ d < 4h                                           |
+        | 2     | 4h ≤ d < 12h                                          |
+        | 3     | 12h ≤ d < 1d                                          |
+        | 4     | 1d ≤ d < 2d                                           |
+        | 5     | 2d ≤ d < 5d                                           |
+        | 6     | 5d ≤ d < 7d                                           |
+        | 7     | 7d ≤ d < 14d                                          |
+        | 8     | 14d ≤ d < 30d                                         |
+        | 9     | 30d ≤ d < 60d                                         |
+        | 10    | 60d ≤ d < 90d                                         |
+        | 11    | 90d ≤ d < 180d                                        |
+        | 12    | 180d ≤ d < 1y                                         |
+        | 13    | 1y ≤ d < 2y                                           |
+        | 14    | 2y ≤ d < 3y                                           |
+        | 15    | 3y+                                                   |
+
+        Special states use negative and zero values so the band signal is compact and
+        self-contained: `0` means no SIM change has happened, and `-1` distinguishes a valid
+        subscriber with unavailable real-time profile data from both "no change" (`0`) and the
+        actual recency buckets (`1`–`15`).
+
+        NOTE: A newer CAMARA Commonalities release introduces a business-outcome modeling pattern
+        (a primary outcome value plus optional `contextCode`/`contextMessage`) that would express
+        the "no real-time profile" state via a context code rather than the `-1` sentinel.
+        Adopting that pattern would require bumping `x-camara-commonalities` for the whole API and
+        is intentionally NOT done in this PR; it should be raised explicitly as a separate change.
+      enum:
+        - -1
+        - 0
+        - 1
+        - 2
+        - 3
+        - 4
+        - 5
+        - 6
+        - 7
+        - 8
+        - 9
+        - 10
+        - 11
+        - 12
+        - 13
+        - 14
+        - 15
+      example: 2
+    SimSwapAgeBandInfo:
+      type: object
+      required:
+        - simSwapAgeBandEnum
+      description: |
+        Response schema for the /retrieve-age-band endpoint. Returns ONLY the standardized recency
+        band. This endpoint deliberately excludes the `swapped` Boolean (provided by `/check`)
+        and the SIM change timestamp (provided by `/retrieve-date`) so that each endpoint
+        contract stays single-purpose and unambiguous. Consuming parties apply their own risk
+        thresholds, ML features, or step-up logic against the returned band value outside the
+        API contract.
+      properties:
+        simSwapAgeBandEnum:
+          $ref: "#/components/schemas/SimSwapAgeBandEnum"
     PhoneNumber:
       type: string
       pattern: '^\+[1-9][0-9]{4,14}$'
@@ -277,6 +449,11 @@ components:
           maximum: 2400
           default: 240
     CreateSimSwapDate:
+      type: object
+      properties:
+        phoneNumber:
+          $ref: "#/components/schemas/PhoneNumber"
+    CreateSimSwapAgeBand:
       type: object
       properties:
         phoneNumber:
@@ -492,3 +669,26 @@ components:
       summary: Retrieve request with 3-legged access tokens
       value:
         {}
+    AGEBAND_2LEGS:
+      summary: Age band request without 3-legged access tokens
+      value:
+        phoneNumber: "+346661113334"
+    AGEBAND_3LEGS:
+      summary: Age band request with 3-legged access tokens
+      value: {}
+    AGEBAND_RECENT:
+      summary: SIM was swapped between 4h and 12h ago (band 2)
+      value:
+        simSwapAgeBandEnum: 2
+    AGEBAND_NO_CHANGE:
+      summary: No SIM change has occurred (band 0)
+      value:
+        simSwapAgeBandEnum: 0
+    AGEBAND_NO_PROFILE:
+      summary: Subscriber valid but no real-time profile available (band -1)
+      value:
+        simSwapAgeBandEnum: -1
+    AGEBAND_LONG_TERM:
+      summary: SIM unchanged for 3 years or more (band 15)
+      value:
+        simSwapAgeBandEnum: 15


### PR DESCRIPTION
**Title:** feat: add `/retrieve-age-band` endpoint returning SIM swap age band only

Adds a third, single-purpose operation that returns the standardized `simSwapAgeBandEnum` only; excludes the `swapped` Boolean (`/check`) and the change date (`/retrieve-date`) per the 2026-04-29 ad-hoc agreement (#253) and TEF stance (#260). Targeting release **2.1.0**.

#### What type of PR is this?

> enhancement/feature

#### What this PR does / why we need it:

Adds `POST /retrieve-age-band` to the SIM Swap API, a third endpoint that returns a standardized recency band (`simSwapAgeBandEnum`) for the last SIM swap/activation event — and nothing else.

- **Purely additive.** `/check` and `/retrieve-date` (and their schemas, request bodies, and examples) are preserved unchanged. The only additions are the new path, the `SimSwapAgeBandEnum` / `SimSwapAgeBandInfo` / `CreateSimSwapAgeBand` schemas, the `AGEBAND_*` examples, and the description/scope updates.
- **Single-purpose by design.** The response carries the band value only. It does **not** include the `swapped` Boolean (that is `/check`) or the SIM change timestamp (that is `/retrieve-date`), keeping each endpoint contract clean — which is the scope agreed on the 2026-04-29 ad-hoc call (#253) and in TEF's position on #260, and which addresses the scope concern raised on #254.
- **Band mapping** retains the standardized values: `-1` = subscriber valid but no real-time profile, `0` = no change, `1`–`15` = recency buckets (4h → 3y+).
- **New scope** `sim-swap:retrieve-age-band`, alongside the existing `sim-swap:check` and `sim-swap:retrieve-date` and the API-level `sim-swap` scope.

Adding a new endpoint is a backward-compatible change, so this targets a MINOR bump to **2.1.0** (URL path unchanged: `/sim-swap/v2`).

#### Which issue(s) this PR fixes:

<!-- Fixes #260 -->


#### Special notes for reviewers:

- **Scope is the point.** Per #253/#260 this is deliberately a *third* endpoint exposing the age band alone — not an extension of `/check` or `/retrieve-date`. Please flag if any check/date logic has leaked in. Supersedes #254.
- **Additive, not a rewrite.** The diff should show **no deletions** in the `/check` or `/retrieve-date` blocks. If you see those as removed, the wrong (single-endpoint) file was committed.
- **Commonalities deferred on purpose.** This keeps the `-1` sentinel and `x-camara-commonalities: 0.6`. Aligning the age-band response to the newer Commonalities business-outcome pattern (`contextCode`/`contextMessage` for unknown/unavailable results) would require bumping Commonalities for the whole file and is intentionally **not** done here — raising it as a separate change. Happy to follow up with that bump if the WG prefers.
- **Co-located, not a separate API.** The age band is another read over the same underlying SIM-swap event, alongside `/check` and `/retrieve-date`, so it is added to `sim-swap.yaml` rather than split into an atomic API. Open to discussion.
- **Version field** stays `wip` on `main`; the release number (2.1.0) is assigned at release time.

#### Changelog input

```release-note
Added a new `POST /retrieve-age-band` endpoint returning the standardized SIM swap recency band (`simSwapAgeBandEnum`) only, without the `swapped` Boolean or change date. Existing `/check` and `/retrieve-date` endpoints are unchanged.
```

#### Additional documentation

This section can be blank.

```docs

```