### PR TITLE
fix(release-plan): set target_api_status to alpha for the alpha pre-release

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -34,14 +34,14 @@ dependencies:
 apis:
   - api_name: sim-swap-subscriptions
     target_api_version: 0.4.0
-    target_api_status: public
+    target_api_status: alpha
     main_contacts:
       - bigludo7
       - fernandopradocabrillo
       - maxl2287
   - api_name: sim-swap
     target_api_version: 2.2.0
-    target_api_status: public
+    target_api_status: alpha
     main_contacts:
       - bigludo7
       - fernandopradocabrillo


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Sets `target_api_status` to `alpha` for both APIs in `release-plan.yaml`, matching `target_release_type: pre-release-alpha`. They were set to `public`, which declares GA maturity and applies the full public-status validation strictness — not appropriate for an alpha pre-release.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Release-plan only; no API definition changes.

#### Changelog input

```
 release-note
Correct release-plan target_api_status to alpha for the alpha pre-release
```

#### Additional documentation

This section can be blank.

```
docs

```
