### PR TITLE
Proposal for adding (optional) SIM type information

### DIFF
--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -50,7 +50,7 @@ info:
       - when assuredTransfer=true: the CSP knows the SIM swap to an eSIM was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device, for example by Apple eSIM Quick Transfer or Android eSIM Transfer functionality
       - when assuredTransfer=false: the CSP knows the SIM swap was not performed through such an assured transfer flow, for example after the SIM was lost or stolen.
       - if the CSP cannot determine this or does not support the attribute, the field should be omitted.
- 
+
     - POST retrieve-age-band : Returns a standardized `simSwapAgeBand` value indicating how recently a SIM swap occurred, expressed as a time band. This operation is an alternative way to expose SIM swap recency for API providers that do not expose the exact SIM swap date; it does not return the actual SIM swap date. This operation is OPTIONAL. A provider that does not implement it returns `501 NOT_IMPLEMENTED`; consumers can then fall back to `check` and/or `retrieve-date`. The returned value is a technical network signal indicating recency; it is not a customer-side risk score or scoring model. Consuming parties apply their own decisioning outside the API contract.
 
       - Definition of `d`:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -194,12 +194,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/SimSwapInfo"
               examples:
-                RETRIEVE_DATE:
-                  $ref: "#/components/examples/RETRIEVE_DATE"
+                RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION:
+                  $ref: "#/components/examples/RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION"
                 RETRIEVE_MONITORED_PERIOD:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_PERIOD"
                 RETRIEVE_MONITORED_NULL:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_NULL"
+                RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION:  
+                  $ref: "#/components/examples/RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -12,7 +12,7 @@ info:
 
     The SIM Swap API can also be used to protect non-automated actions. For example, when a call center expert contacts a user to clarify or confirm a sensitive operation.
 
-    This API is used by an application to get information about a mobile line latest SIM swap date. It can be easily integrated and used through this secured API and allows SPs (Service Provider) to get this information an easy & secured way. The API provides management of 3 endpoints answering 3 distinct questions: 
+    This API is used by an application to get information about a mobile line latest SIM swap date. It can be easily integrated and used through this secured API and allows SPs (Service Provider) to get this information an easy & secured way. The API provides management of 3 endpoints answering 3 distinct questions:
     An API provider is not expected to support all of them: the age-band operation is an alternative to exposing the exact SIM swap date, and support depends on the provider's available capabilities and commercial use case.
 
     * When did the last SIM swap occur?
@@ -41,16 +41,16 @@ info:
       - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then,  an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
 
     Additional information can optionally be returned:
-    
+
     - simType : what type of SIM (eSIM of physical SIM) the phone number is associated with after the relevant SIM Swap event:
       - for /check, the latest swap within the requested maxAge window;
       - for /retrieve-date, the event behind latestSimChange.
-    
+
     - assuredTransfer : indicator of what level assurance / risk can be expected to be associated with the SIM Swap event
       - when assuredTransfer=true: the CSP knows the SIM swap to an eSIM was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device, for example by Apple eSIM Quick Transfer or Android eSIM Transfer functionality
       - when assuredTransfer=false: the CSP knows the SIM swap was not performed through such an assured transfer flow, for example after the SIM was lost or stolen.
       - if the CSP cannot determine this or does not support the attribute, the field should be omitted.
-        
+ 
     - POST retrieve-age-band : Returns a standardized `simSwapAgeBand` value indicating how recently a SIM swap occurred, expressed as a time band. This operation is an alternative way to expose SIM swap recency for API providers that do not expose the exact SIM swap date; it does not return the actual SIM swap date. This operation is OPTIONAL. A provider that does not implement it returns `501 NOT_IMPLEMENTED`; consumers can then fall back to `check` and/or `retrieve-date`. The returned value is a technical network signal indicating recency; it is not a customer-side risk score or scoring model. Consuming parties apply their own decisioning outside the API contract.
 
       - Definition of `d`:
@@ -80,7 +80,7 @@ info:
         | 16 | 2y ≤ d < 3y |
         | 17 | 3y+ |
         | 111 | SIM swap has never happened; positively confirmed (and never ported). Sentinel, not an ordinal band |
-    
+
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
@@ -200,7 +200,7 @@ paths:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_PERIOD"
                 RETRIEVE_MONITORED_NULL:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_NULL"
-                RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION:  
+                RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION:
                   $ref: "#/components/examples/RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
@@ -270,7 +270,7 @@ paths:
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic429"
 
   # Alternative operation: exposes SIM swap recency as a time band for providers that do not expose the exact SIM swap date.
-  # Support is optional and provider-dependent. 
+  # Support is optional and provider-dependent.
   # Returns the age-band value only.
   /retrieve-age-band:
     post:
@@ -758,7 +758,7 @@ components:
       value:
         swapped: true
         simType: "pSIM"
-        assuredTransfer: false       
+        assuredTransfer: false
     CHECK_2LEGS:
       summary: Check request without 3-legged access tokens
       description: Check request in 2-legs (with phoneNumber in the request body)

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -714,7 +714,7 @@ components:
                 code: NOT_IMPLEMENTED
                 message: This functionality is not implemented by the provider.
   examples:
-    RETRIEVE_DATE:
+    RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION:
       summary: Lastest SIM swap date is send back
       description: Lastest SIM swap date is send back
       value:
@@ -730,6 +730,13 @@ components:
       value:
         latestSimChange: null
         monitoredPeriod: 120
+    RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION:
+      summary: Lastest SIM swap date is send back including simType and assuredTransfer information
+      description: Lastest SIM swap date is send back, and the new sim is an eSIM generated in a process where the old SIM was confirmed to be present in proximity
+      value:
+        latestSimChange: 2024-09-18T07:37:53.471829447Z
+        simType: "eSIM"
+        assuredTransfer: true
     CHECK_2LEGS:
       summary: Check request without 3-legged access tokens
       description: Check request in 2-legs (with phoneNumber in the request body)

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -42,7 +42,7 @@ info:
     
     - simType : what type of SIM the phone number is currently associated with (either an eSIM or a physical SIM)
     
-    - directTransfer : whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not
+    - assuredTransfer : the SIM swap to an eSIM was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device, for example by Apple eSIM Quick Transfer or Android eSIM Transfer functionality
       
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
@@ -245,9 +245,9 @@ components:
           maxLength: 4
           enum: [eSIM, pSIM]
           description: The type of SIM that is currently active, either an eSIM or a physical SIM card
-        directTransfer:
+        assuredTransfer:
           type: boolean
-          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not
+          description: Indicates whether the SIM swap was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device
     CheckSimSwapInfo:
       type: object
       description: Definition of the data that can be returned in the response body for check operation
@@ -263,9 +263,9 @@ components:
           maxLength: 4
           enum: [eSIM, pSIM]
           description: The type of SIM that is currently active, either an eSIM or a physical SIM card
-        directTransfer:
+        assuredTransfer:
           type: boolean
-          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not   
+          description: Indicates whether the SIM swap was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device
     PhoneNumber:
       $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     CreateCheckSimSwap:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -38,6 +38,12 @@ info:
 
       - Note: In the specification of the API the 'maxAge' could be between 1 hour to 2400 hours. If this delay is not managed due to the operator's own privacy threshold (which in theory would likely be linked to local regulations in the country) and a request is performed with a value inferior to 2400 but superior to operator policy, then,  an error `400 OUT_OF_RANGE `is expected with an explicit message to explain the limitation like `Check monitor period could not exceed local regulations (30 days)`.
 
+    Additional information can optionally be returned:
+    
+    - SIMtype : what type of SIM the phone number is currently associated with (either an eSIM or a physical SIM)
+    
+    - directTransfer : whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not
+      
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
 
@@ -234,6 +240,13 @@ components:
           maximum: 999
           description: Timeframe in days for SIM card change supervision for the phone number. It could be valued in the response if the latest SIM swap occurred before this monitored period.
           example: 120
+        SIMtype:
+          type: string
+          enum: [eSIM, pSIM]
+          description: The type of SIM that is currently active, either an eSIM or a physical SIM card
+        directTransfer:
+          type: boolean
+          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not
     CheckSimSwapInfo:
       type: object
       description: Definition of the data that can be returned in the response body for check operation
@@ -244,6 +257,13 @@ components:
           type: boolean
           description: Indicates whether the SIM card has been swapped during the
             period within the provided age.
+        SIMtype:
+          type: string
+          enum: [eSIM, pSIM]
+          description: The type of SIM that is currently active, either an eSIM or a physical SIM card
+        directTransfer:
+          type: boolean
+          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not   
     PhoneNumber:
       $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     CreateCheckSimSwap:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -194,14 +194,14 @@ paths:
               schema:
                 $ref: "#/components/schemas/SimSwapInfo"
               examples:
-                RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION:
-                  $ref: "#/components/examples/RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION"
+                RETRIEVE_DATE:
+                  $ref: "#/components/examples/RETRIEVE_DATE"
                 RETRIEVE_MONITORED_PERIOD:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_PERIOD"
                 RETRIEVE_MONITORED_NULL:
                   $ref: "#/components/examples/RETRIEVE_MONITORED_NULL"
-                RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION:  
-                  $ref: "#/components/examples/RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION"
+                RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION:  
+                  $ref: "#/components/examples/RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -716,7 +716,7 @@ components:
                 code: NOT_IMPLEMENTED
                 message: This functionality is not implemented by the provider.
   examples:
-    RETRIEVE_DATE_WITHOUT_SYM_TYPE_AND_TRANSER_INFORMATION:
+    RETRIEVE_DATE:
       summary: Lastest SIM swap date is send back
       description: Lastest SIM swap date is send back
       value:
@@ -732,13 +732,22 @@ components:
       value:
         latestSimChange: null
         monitoredPeriod: 120
-    RETRIEVE_DATE_WITH_SYM_TYPE_AND_TRANSER_INFORMATION:
+    RETRIEVE_DATE_WITH_OPTIONAL_SIM_INFORMATION:
       summary: Lastest SIM swap date is send back including simType and assuredTransfer information
       description: Lastest SIM swap date is send back, and the new sim is an eSIM generated in a process where the old SIM was confirmed to be present in proximity
       value:
         latestSimChange: 2024-09-18T07:37:53.471829447Z
         simType: "eSIM"
         assuredTransfer: true
+    CHECK_SIM_SWAP_WITH_OPTIONAL_SIM_INFORMATION:
+      summary: SIM swap detected with optional SIM information
+      description: >
+        A SIM swap is detected within the requested maxAge window, and the
+        response includes optional information about the relevant SIM swap event.
+      value:
+        swapped: true
+        simType: "pSIM"
+        assuredTransfer: false       
     CHECK_2LEGS:
       summary: Check request without 3-legged access tokens
       description: Check request in 2-legs (with phoneNumber in the request body)

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -42,10 +42,15 @@ info:
 
     Additional information can optionally be returned:
     
-    - simType : what type of SIM the phone number is currently associated with (either an eSIM or a physical SIM)
+    - simType : what type of SIM (eSIM of physical SIM) the phone number is associated with after the relevant SIM Swap event:
+      - for /check, the latest swap within the requested maxAge window;
+      - for /retrieve-date, the event behind latestSimChange.
     
-    - assuredTransfer : the SIM swap to an eSIM was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device, for example by Apple eSIM Quick Transfer or Android eSIM Transfer functionality
-      
+    - assuredTransfer : indicator of what level assurance / risk can be expected to be associated with the SIM Swap event
+      - when assuredTransfer=true: the CSP knows the SIM swap to an eSIM was performed through a CSP-verified transfer flow requiring possession/control of the previously active SIM or trusted device, for example by Apple eSIM Quick Transfer or Android eSIM Transfer functionality
+      - when assuredTransfer=false: the CSP knows the SIM swap was not performed through such an assured transfer flow, for example after the SIM was lost or stolen.
+      - if the CSP cannot determine this or does not support the attribute, the field should be omitted.
+        
     - POST retrieve-age-band : Returns a standardized `simSwapAgeBand` value indicating how recently a SIM swap occurred, expressed as a time band. This operation is an alternative way to expose SIM swap recency for API providers that do not expose the exact SIM swap date; it does not return the actual SIM swap date. This operation is OPTIONAL. A provider that does not implement it returns `501 NOT_IMPLEMENTED`; consumers can then fall back to `check` and/or `retrieve-date`. The returned value is a technical network signal indicating recency; it is not a customer-side risk score or scoring model. Consuming parties apply their own decisioning outside the API contract.
 
       - Definition of `d`:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -40,9 +40,9 @@ info:
 
     Additional information can optionally be returned:
     
-    - SIMtype : what type of SIM the phone number is currently associated with (either an eSIM or a physical SIM)
+    - simType : what type of SIM the phone number is currently associated with (either an eSIM or a physical SIM)
     
-    - directTransfer : whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not
+    - directTransfer : whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not
       
     <!-- CAMARA:MANDATORY:authorization-and-authentication:BEGIN -->
     # Authorization and authentication
@@ -240,13 +240,14 @@ components:
           maximum: 999
           description: Timeframe in days for SIM card change supervision for the phone number. It could be valued in the response if the latest SIM swap occurred before this monitored period.
           example: 120
-        SIMtype:
+        simType:
           type: string
+          maxLength: 4
           enum: [eSIM, pSIM]
           description: The type of SIM that is currently active, either an eSIM or a physical SIM card
         directTransfer:
           type: boolean
-          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not
+          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not
     CheckSimSwapInfo:
       type: object
       description: Definition of the data that can be returned in the response body for check operation
@@ -257,13 +258,14 @@ components:
           type: boolean
           description: Indicates whether the SIM card has been swapped during the
             period within the provided age.
-        SIMtype:
+        simType:
           type: string
+          maxLength: 4
           enum: [eSIM, pSIM]
           description: The type of SIM that is currently active, either an eSIM or a physical SIM card
         directTransfer:
           type: boolean
-          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the telecom provider) or not   
+          description: Indicates whether the SIM was directly transferred between devices (without the user contacting the Telecom Operator) or not   
     PhoneNumber:
       $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
     CreateCheckSimSwap:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -781,9 +781,9 @@ components:
       value:
         {}
     AGEBAND_2LEGS:
-          summary: Age band request without 3-legged access tokens
-          value:
-            phoneNumber: "+346661113334"
+      summary: Age band request without 3-legged access tokens
+      value:
+        phoneNumber: "+346661113334"
     AGEBAND_3LEGS:
       summary: Age band request with 3-legged access tokens
       value: {}

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -251,6 +251,11 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/CheckSimSwapInfo"
+              examples:
+                CHECK_SIM_SWAP:
+                  $ref: "#/components/examples/CHECK_SIM_SWAP"
+                CHECK_SIM_SWAP_WITH_OPTIONAL_SIM_INFORMATION:
+                  $ref: "#/components/examples/CHECK_SIM_SWAP_WITH_OPTIONAL_SIM_INFORMATION"
         "400":
           $ref: "../common/CAMARA_common.yaml#/components/responses/Generic400"
         "401":
@@ -739,6 +744,12 @@ components:
         latestSimChange: 2024-09-18T07:37:53.471829447Z
         simType: "eSIM"
         assuredTransfer: true
+    CHECK_SIM_SWAP:
+      summary: SIM swap detected
+      description: >
+        A SIM swap is detected within the requested maxAge window.
+      value:
+        swapped: true
     CHECK_SIM_SWAP_WITH_OPTIONAL_SIM_INFORMATION:
       summary: SIM swap detected with optional SIM information
       description: >

--- a/code/Test_definitions/sim-swap-retrieveSimSwapDate.feature
+++ b/code/Test_definitions/sim-swap-retrieveSimSwapDate.feature
@@ -63,6 +63,28 @@ Feature: CAMARA SIM Swap API, vwip - Operation retrieveSimSwapDate
     And the response property "$.latestSimChange" is null
     And the response optionally contains the property "$.monitoredPeriod" with the value of monitored time frame (in days) supported by the MNO
 
+  # This scenario applies when the returned information includes the eSIM type and assurance of the transfer
+  @retrieve_sim_swap_date_6_optional_sim_swap_information_present
+  Scenario: Retrieves SIM swap date for a valid SIM swap, new SIM is an eSIM and it is an assured transfer proces
+    Given a valid phone number identified by the token or provided in the request body
+    And the SIM for this phone number has been swapped before the limited history window threshold
+    When the request "retrieveSimSwapDate" is sent
+    Then the response status code is 200
+    And the response property "$.latestSimChange" is null
+    And the response optionally contains the property "$.simType" is "eSIM"
+    And the response optionally contains the property "$.assuredTransfer" is True
+
+ # This scenario applies when the returned information includes the physical SIM type and no assurance of the transfer
+  @retrieve_sim_swap_date_7_optional_sim_swap_information_present
+  Scenario: Retrieves SIM swap date for a valid SIM swap, new SIM is an physical SIM and it is not an assured transfer proces
+    Given a valid phone number identified by the token or provided in the request body
+    And the SIM for this phone number has been swapped before the limited history window threshold
+    When the request "retrieveSimSwapDate" is sent
+    Then the response status code is 200
+    And the response property "$.latestSimChange" is null
+    And the response optionally contains the property "$.simType" is "pSIM"
+    And the response optionally contains the property "$.assuredTransfer" is False
+
   # Generic 401 errors
 
   @retrieve_sim_swap_date_401.1_no_authorization_header

--- a/code/Test_definitions/sim-swap-retrieveSimSwapDate.feature
+++ b/code/Test_definitions/sim-swap-retrieveSimSwapDate.feature
@@ -63,27 +63,61 @@ Feature: CAMARA SIM Swap API, vwip - Operation retrieveSimSwapDate
     And the response property "$.latestSimChange" is null
     And the response optionally contains the property "$.monitoredPeriod" with the value of monitored time frame (in days) supported by the MNO
 
-  # This scenario applies when the returned information includes the eSIM type and assurance of the transfer
-  @retrieve_sim_swap_date_6_optional_sim_swap_information_present
-  Scenario: Retrieves SIM swap date for a valid SIM swap, new SIM is an eSIM and it is an assured transfer proces
+  # This scenario applies when the returned information includes the eSIM type
+  # and assurance of the transfer.
+  @retrieve_sim_swap_date_6_optional_sim_swap_information_esim_assured
+  Scenario: Retrieves SIM swap date with eSIM and assured transfer information
     Given a valid phone number identified by the token or provided in the request body
-    And the SIM for this phone number has been swapped before the limited history window threshold
+    And the SIM for this phone number has been swapped within the retrievable history window
+    And the SIM type associated with the relevant SIM swap event is "eSIM"
+    And the relevant SIM swap event was performed through an assured transfer flow
     When the request "retrieveSimSwapDate" is sent
     Then the response status code is 200
-    And the response property "$.latestSimChange" is null
-    And the response optionally contains the property "$.simType" is "eSIM"
-    And the response optionally contains the property "$.assuredTransfer" is True
+    And the response property "$.latestSimChange" contains a valid timestamp
+    And the response optionally contains the property "$.simType" with value "eSIM"
+    And the response optionally contains the property "$.assuredTransfer" with value true
+    
+  # This scenario applies when the returned information includes the physical SIM type
+  # and the transfer is known not to be assured.
+  @retrieve_sim_swap_date_7_optional_sim_swap_information_psim_not_assured
+  Scenario: Retrieves SIM swap date with pSIM and non-assured transfer information
+    Given a valid phone number identified by the token or provided in the request body
+    And the SIM for this phone number has been swapped within the retrievable history window
+    And the SIM type associated with the relevant SIM swap event is "pSIM"
+    And the relevant SIM swap event was not performed through an assured transfer flow
+    When the request "retrieveSimSwapDate" is sent
+    Then the response status code is 200
+    And the response property "$.latestSimChange" contains a valid timestamp
+    And the response optionally contains the property "$.simType" with value "pSIM"
+    And the response optionally contains the property "$.assuredTransfer" with value false
 
- # This scenario applies when the returned information includes the physical SIM type and no assurance of the transfer
-  @retrieve_sim_swap_date_7_optional_sim_swap_information_present
-  Scenario: Retrieves SIM swap date for a valid SIM swap, new SIM is an physical SIM and it is not an assured transfer proces
+
+# This scenario applies when a SIM swap is detected and optional SIM information is returned.
+  @check_sim_swap_8_optional_sim_swap_information_esim_assured
+  Scenario: Check SIM swap with eSIM and assured transfer information
     Given a valid phone number identified by the token or provided in the request body
-    And the SIM for this phone number has been swapped before the limited history window threshold
-    When the request "retrieveSimSwapDate" is sent
+    And the SIM for this phone number has been swapped within the requested maxAge window
+    And the SIM type associated with the latest SIM swap event within the maxAge window is "eSIM"
+    And the latest SIM swap event within the maxAge window was performed through an assured transfer flow
+    When the request "checkSimSwap" is sent
     Then the response status code is 200
-    And the response property "$.latestSimChange" is null
-    And the response optionally contains the property "$.simType" is "pSIM"
-    And the response optionally contains the property "$.assuredTransfer" is False
+    And the value of response property "$.swapped" == true
+    And the response optionally contains the property "$.simType" with value "eSIM"
+    And the response optionally contains the property "$.assuredTransfer" with value true
+
+# This scenario applies when a SIM swap is detected and optional SIM information is returned.
+  @check_sim_swap_9_optional_sim_swap_information_psim_not_assured
+  Scenario: Check SIM swap with pSIM and non-assured transfer information
+    Given a valid phone number identified by the token or provided in the request body
+    And the SIM for this phone number has been swapped within the requested maxAge window
+    And the SIM type associated with the latest SIM swap event within the maxAge window is "pSIM"
+    And the latest SIM swap event within the maxAge window was not performed through an assured transfer flow
+    When the request "checkSimSwap" is sent
+    Then the response status code is 200
+    And the value of response property "$.swapped" == true
+    And the response optionally contains the property "$.simType" with value "pSIM"
+    And the response optionally contains the property "$.assuredTransfer" with value false
+
 
   # Generic 401 errors
 


### PR DESCRIPTION
#### What type of PR is this?


* enhancement/feature


#### What this PR does / why we need it:

Customers that use the SIM Swap API in combination with Number Verify immediately after the user has migrated to a new device experience a  large number of false positives due to eSIMs.  By recognizing eSIMs and in particular the type of transfer with eSIMs, the API Consumer can correct for this.


#### Which issue(s) this PR fixes:

<!-- Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`. -->

Fixes #241 

#### Special notes for reviewers:
@bigludo7 @jlurien @fernandopradocabrillo   Can you please review and approve this PR for fixing the false positives problem with eSIMs?


#### Changelog input

```
 release-note

```

#### Additional documentation 

This section can be blank.



```
docs

```
