### PR TITLE
Fix  inconsistencies in sim-swap-subscriptions.yaml

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -372,13 +372,15 @@ components:
         subscriptionExpireTime:
           type: string
           format: date-time
-          example: 2025-01-17T13:18:23.682Z
+          maxLength: 64
+          example: 2023-01-17T13:18:23.682Z
           description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
         subscriptionMaxEvents:
           type: integer
-          description: |
-            Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends.
+          format: int32
+          description: Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends.
           minimum: 1
+          maximum: 1000000
           example: 5
 
     ApiEventType:

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -680,7 +680,6 @@ components:
         specversion: "1.0"
         datacontenttype: application/json
         data:
-          phoneNumber: "+123456789"
           terminationReason: SUBSCRIPTION_EXPIRED
           subscriptionId: 2ghy-55gg-7iup-yuo9
           terminationDescription: subscription expire time reached

--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -359,13 +359,27 @@ components:
           $ref: "../common/CAMARA_common.yaml#/components/schemas/PhoneNumber"
 
     Config:
-      description: Config schema allowing for device to be specified as part of subscription detail
-      allOf:
-        - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/Config"
-        - type: object
-          properties:
-            subscriptionDetail:
-              $ref: "#/components/schemas/CreateSubscriptionDetail"
+      description: |
+        Implementation-specific configuration parameters needed by the subscription manager for acquiring events.
+        In CAMARA we have predefined attributes like `subscriptionExpireTime` or `subscriptionMaxEvents` to limit subscription lifetime.
+        Event type attributes must be defined in `subscriptionDetail`
+      type: object
+      required:
+        - subscriptionDetail
+      properties:
+        subscriptionDetail:
+          $ref: "#/components/schemas/CreateSubscriptionDetail"
+        subscriptionExpireTime:
+          type: string
+          format: date-time
+          example: 2025-01-17T13:18:23.682Z
+          description: The subscription expiration time (in date-time format) requested by the API consumer. It must follow [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339#section-5.6) and must have time zone.
+        subscriptionMaxEvents:
+          type: integer
+          description: |
+            Identifies the maximum number of event reports to be generated (>=1) requested by the API consumer - Once this number is reached, the subscription ends.
+          minimum: 1
+          example: 5
 
     ApiEventType:
       type: string
@@ -467,11 +481,9 @@ components:
           - "org.camaraproject.sim-swap-subscriptions.v0.swapped"
         config:
           subscriptionDetail:
-            device:
-              phoneNumber: "+123456789"
+            phoneNumber: "+123456789"
           subscriptionExpireTime: "2024-07-17T13:18:23.682Z"
           subscriptionMaxEvents: 5
-          initialEvent: true
         startsAt: "2024-07-03T21:12:02.871Z"
         expiresAt: "2024-07-03T21:12:02.871Z"
         status: ACTIVE
@@ -599,12 +611,7 @@ components:
         - type: object
           properties:
             data:
-              allOf:
-                - type: object
-                  properties:
-                    device:
-                      $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionStarted"
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionStarted"
 
     EventSubscriptionUpdated:
       description: event structure for event subscription updated
@@ -613,12 +620,7 @@ components:
         - type: object
           properties:
             data:
-              allOf:
-                - type: object
-                  properties:
-                    device:
-                      $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionUpdated"
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionUpdated"
 
     EventSubscriptionEnded:
       description: event structure for event subscription ended
@@ -627,12 +629,7 @@ components:
         - type: object
           properties:
             data:
-              allOf:
-                - type: object
-                  properties:
-                    device:
-                      $ref: "../common/CAMARA_common.yaml#/components/schemas/DeviceResponse"
-                - $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionEnded"
+              $ref: "../common/CAMARA_event_common.yaml#/components/schemas/SubscriptionEnded"
 
     Sink:
       description: The address to which events shall be delivered using the selected protocol.


### PR DESCRIPTION
#### What type of PR is this?

* correction


#### What this PR does / why we need it:

Fixes schema/example drift in `code/API_definitions/sim-swap-subscriptions.yaml` around the `Config` schema and the subscription lifecycle event payloads.

- **Restore local `Config` schema**: replaced the `allOf` extension of the shared `CAMARA_event_common.yaml#/components/schemas/Config` with a fully-local `Config` schema (`subscriptionDetail`, `subscriptionExpireTime`, `subscriptionMaxEvents`), matching the historical `r3.3` definition. The shared `Config` schema also carries an `initialEvent` property that this API does not use; extending it silently pulled that property in. Since the local `Config` no longer inherits `initialEvent`, the stray `initialEvent: true` was also removed from the `Subscription` schema's inline example.
- **Fix `subscriptionDetail` example nesting**: the same `Subscription` example incorrectly nested `phoneNumber` under an extra `device` key (`subscriptionDetail.device.phoneNumber`), which doesn't match the `CreateSubscriptionDetail` schema (a flat `phoneNumber` property) and was inconsistent with every other example in the file. Corrected to `subscriptionDetail.phoneNumber`.
- **Simplify `EventSubscriptionStarted`/`Updated`/`Ended`**: these previously wrapped the shared `SubscriptionStarted`/`Updated`/`Ended` payload schemas in an extra `allOf` that injected a local `device`/`DeviceResponse` field.  Simplified all three to a direct `$ref`, matching the template.
- **Fix `SUBSCRIPTION_ENDS` example**: removed the invalid `phoneNumber` field from the notification payload under `data`. The `SubscriptionEnded` schema (from `CAMARA_event_common.yaml`) only defines `terminationReason`, `subscriptionId`, and `terminationDescription`; the example now matches the schema exactly.

Verified against the `r3.3` release tag and the current Commonalities event-subscription template that these are genuine drift/inconsistencies rather than intentional SimSwap-specific extensions.


#### Which issue(s) this PR fixes:

Fixes #279 

#### Special notes for reviewers:

- No changes were made to the `/subscriptions` or `/subscriptions/{subscriptionId}` path operations, security schemes, or response definitions — this PR is scoped to the `Config`, `Subscription` example, and `EventSubscriptionStarted`/`Updated`/`Ended` schemas only.
- The `Config` restoration aligns with the [r3.3](https://github.com/camaraproject/SimSwap/blob/r3.3/code/API_definitions/sim-swap-subscriptions.yaml) release tag.
- The `EventSubscriptionStarted`/`Updated`/`Ended` simplification aligns with the current Commonalities template (`sample-service-subscriptions.yaml`) and the [r3.3](https://github.com/camaraproject/SimSwap/blob/r3.3/code/API_definitions/sim-swap-subscriptions.yaml) release tag.
- The `SUBSCRIPTION_ENDS` example fix aligns the notification payload with the `SubscriptionEnded` schema from `CAMARA_event_common.yaml`.

Validation errors are resolved within https://github.com/camaraproject/SimSwap/pull/278 (should be merged first).

#### Changelog input

```
 release-note
Restore local Config schema in the SIM Swap Subscriptions API and align EventSubscriptionStarted/Updated/Ended with the Commonalities subscription template.
```

#### Additional documentation 
