### PR TITLE
Target Sync26 release as pre-release-rc instead of alpha

### DIFF
--- a/release-plan.yaml
+++ b/release-plan.yaml
@@ -20,7 +20,7 @@ repository:
 
   # Release type being prepared (must be set before release can be triggered)
   # Options: none | pre-release-alpha | pre-release-rc | public-release | maintenance-release
-  target_release_type: pre-release-alpha
+  target_release_type: pre-release-rc
 
 # Dependencies on Commonalities and ICM releases
 # Update per ReleaseManagement requirements for each release cycle
@@ -34,14 +34,14 @@ dependencies:
 apis:
   - api_name: sim-swap-subscriptions
     target_api_version: 0.4.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - bigludo7
       - fernandopradocabrillo
       - maxl2287
   - api_name: sim-swap
     target_api_version: 2.2.0
-    target_api_status: alpha
+    target_api_status: rc
     main_contacts:
       - bigludo7
       - fernandopradocabrillo


### PR DESCRIPTION
#### What type of PR is this?

subproject management

#### What this PR does / why we need it:

Updates the Sync26 release plan to target a release candidate (rc) instead of an alpha pre-release for both APIs (`sim-swap-subscriptions` 0.4.0, `sim-swap` 2.2.0). Sets `target_release_type` to `pre-release-rc` and both `target_api_status` fields to `rc`, matching the schema requirement that all APIs be `rc` or `public` for a `pre-release-rc` repository release type.

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

This changes release intent only; it does not touch API definitions or test files. Please confirm both APIs are feature-complete enough for rc before merging — if not, hold at alpha and revisit this proposal later in the cycle.

#### Changelog input

```
 release-note
Target Sync26 release type set to pre-release-rc for sim-swap and sim-swap-subscriptions.
```

#### Additional documentation

This section can be blank.

```
docs

```
