### PR TITLE
Fix externalDocs validation findings from #281

### DIFF
--- a/code/API_definitions/sim-swap-subscriptions.yaml
+++ b/code/API_definitions/sim-swap-subscriptions.yaml
@@ -111,7 +111,7 @@ info:
 
 externalDocs:
   description: Product documentation at CAMARA
-  url: https://github.com/camaraproject/
+  url: https://github.com/camaraproject/SimSwap
 servers:
   - url: '{apiRoot}/sim-swap-subscriptions/vwip'
     variables:

--- a/code/API_definitions/sim-swap.yaml
+++ b/code/API_definitions/sim-swap.yaml
@@ -128,7 +128,7 @@ info:
   version: wip
   x-camara-commonalities: 0.6
 externalDocs:
-  description: Product documentation at Camara
+  description: Product documentation at CAMARA
   url: https://github.com/camaraproject/SimSwap
 servers:
   - url: "{apiRoot}/sim-swap/vwip"


### PR DESCRIPTION
#### What type of PR is this?

correction

#### What this PR does / why we need it:

Fixes two CAMARA Validation findings flagged on #281:
- `code/API_definitions/sim-swap.yaml`: `externalDocs.description` was "Product documentation at Camara" (wrong capitalization) — set to "Product documentation at CAMARA" (P-039).
- `code/API_definitions/sim-swap-subscriptions.yaml`: `externalDocs.url` was "https://github.com/camaraproject/" (missing repo name) — set to "https://github.com/camaraproject/SimSwap" (P-038).

#### Which issue(s) this PR fixes:

Fixes #

#### Special notes for reviewers:

Metadata-only fix, no behavioral change to either API definition.

#### Changelog input

```
 release-note
Fixed externalDocs.description capitalization in sim-swap.yaml and externalDocs.url in sim-swap-subscriptions.yaml.
```

#### Additional documentation

This section can be blank.

```
docs

```
